### PR TITLE
Add responsive hamburger navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,12 +16,15 @@
   <div class="logo">
     <img src="assets/images/dataraiils-logo.png" alt="Dataraiils Logo" style="height: 32px;">
   </div>
+  <button id="nav-toggle" aria-label="Toggle navigation">☰</button>
   <nav>
-    <a href="#product" class="nav-link">Product</a>
-    <a href="#how-it-works" class="nav-link">How It Works</a>
-    <a href="#bottleneck" class="nav-link">The Bottleneck</a>
-    <a href="#about" class="nav-link">About</a>
-    <a href="#demo" class="button-primary">Fix Trafficking</a>
+    <div id="nav-menu">
+      <a href="#product" class="nav-link">Product</a>
+      <a href="#how-it-works" class="nav-link">How It Works</a>
+      <a href="#bottleneck" class="nav-link">The Bottleneck</a>
+      <a href="#about" class="nav-link">About</a>
+      <a href="#demo" class="button-primary">Fix Trafficking</a>
+    </div>
   </nav>
 </header>
 
@@ -216,17 +219,23 @@
 
 <script>
   // Optional scroll animation support
-  const reveal = () => {
-    const elements = document.querySelectorAll('.fade-in');
-    const triggerBottom = window.innerHeight * 0.9;
-    elements.forEach(el => {
-      const boxTop = el.getBoundingClientRect().top;
-      if (boxTop < triggerBottom) el.classList.add('visible');
+    const reveal = () => {
+      const elements = document.querySelectorAll('.fade-in');
+      const triggerBottom = window.innerHeight * 0.9;
+      elements.forEach(el => {
+        const boxTop = el.getBoundingClientRect().top;
+        if (boxTop < triggerBottom) el.classList.add('visible');
+      });
+    };
+    window.addEventListener('scroll', reveal);
+    window.addEventListener('load', reveal);
+
+    const navToggle = document.getElementById('nav-toggle');
+    const navMenu = document.getElementById('nav-menu');
+    navToggle.addEventListener('click', () => {
+      navMenu.classList.toggle('open');
     });
-  };
-  window.addEventListener('scroll', reveal);
-  window.addEventListener('load', reveal);
-</script>
+  </script>
 
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -69,6 +69,24 @@ blockquote {
   font-weight: 500;
 }
 
+#nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+#nav-menu {
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+
+#nav-menu .button-primary {
+  margin-left: 20px;
+}
+
 /* Buttons */
 .button-primary {
   background-color: #9605DF;
@@ -144,25 +162,46 @@ footer {
 
 /* Media Queries */
 @media screen and (max-width: 768px) {
-  h1 {
-    font-size: 36px;
+    h1 {
+      font-size: 36px;
+    }
+    h2 {
+      font-size: 24px;
+    }
+    .hero-content {
+      padding: 40px 24px;
+      max-width: 100%;
+    }
+    .nav-bar {
+      flex-direction: row;
+      align-items: center;
+    }
+    #nav-toggle {
+      display: block;
+    }
+    #nav-menu {
+      display: none;
+      flex-direction: column;
+      width: 100%;
+      position: relative;
+      padding: 20px 0 60px;
+      height: 100vh;
+    }
+    #nav-menu.open {
+      display: flex;
+    }
+    .nav-link {
+      margin: 8px 0;
+    }
+    #nav-menu .button-primary {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      margin-left: 0;
+    }
+    .button-secondary {
+      display: block;
+      margin: 12px 0 0;
+    }
   }
-  h2 {
-    font-size: 24px;
-  }
-  .hero-content {
-    padding: 40px 24px;
-    max-width: 100%;
-  }
-  .nav-bar {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-  .nav-link {
-    margin: 8px 0;
-  }
-  .button-secondary {
-    display: block;
-    margin: 12px 0 0;
-  }
-}


### PR DESCRIPTION
## Summary
- add mobile-friendly hamburger button and wrap links in a hidden `#nav-menu`
- style menu to toggle visibility and pin CTA link to bottom on small screens
- toggle the menu open/closed via a small script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893ef860c5c8329bb6916f6769fb6b9