### PR TITLE
feat: add sticky navbar with shrinkable logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,9 @@
 <body>
 
 <header class="nav-bar">
-  <div class="logo">
-    <img src="assets/images/dataraiils-logo.png" alt="Dataraiils Logo" style="height: 32px;">
-  </div>
+  <a href="/" class="logo">
+    <img src="assets/images/dataraiils-logo.png" alt="Dataraiils Logo">
+  </a>
   <nav>
     <a href="#product" class="nav-link">Product</a>
     <a href="#how-it-works" class="nav-link">How It Works</a>
@@ -207,12 +207,14 @@
 
 <footer>
   <p>
-    © 2025 dataraiils.ai — 
-    <a href="privacy.html">Privacy</a> | 
-    <a href="terms.html">Terms</a> | 
+    © 2025 dataraiils.ai —
+    <a href="privacy.html">Privacy</a> |
+    <a href="terms.html">Terms</a> |
     <a href="mailto:hello@dataraiils.ai">Contact</a>
   </p>
 </footer>
+
+<script src="main.js"></script>
 
 <script>
   // Optional scroll animation support

--- a/main.js
+++ b/main.js
@@ -1,0 +1,7 @@
+window.addEventListener('scroll', () => {
+  const header = document.querySelector('.nav-bar');
+  if (header) {
+    header.classList.toggle('shrink', window.scrollY > 50);
+  }
+});
+

--- a/style.css
+++ b/style.css
@@ -55,6 +55,10 @@ blockquote {
 
 /* Nav */
 .nav-bar {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -67,6 +71,15 @@ blockquote {
   color: #1B1B1F;
   text-decoration: none;
   font-weight: 500;
+}
+
+.logo img {
+  height: 40px;
+  transition: height 0.2s ease;
+}
+
+.nav-bar.shrink .logo img {
+  height: 32px;
 }
 
 /* Buttons */


### PR DESCRIPTION
## Summary
- make navigation bar sticky at top with shrinking logo on scroll
- style logo size and add shrink class handling for header
- add scroll listener script to toggle shrinking effect

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893ef4d0b608329bb07b817ac4231c0