### PR TITLE
Add pain, proof, FAQ, and contact sections to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,10 @@
   <nav>
     <a href="#product" class="nav-link">Product</a>
     <a href="#how-it-works" class="nav-link">How It Works</a>
-    <a href="#bottleneck" class="nav-link">The Bottleneck</a>
-    <a href="#about" class="nav-link">About</a>
+    <a href="#inside-the-pain" class="nav-link">Inside the Pain</a>
+    <a href="#proof" class="nav-link">Proof</a>
+    <a href="#faq" class="nav-link">FAQ</a>
+    <a href="#contact" class="nav-link">Contact</a>
     <a href="#demo" class="button-primary">Fix Trafficking</a>
   </nav>
 </header>
@@ -121,12 +123,12 @@
   </div>
 </section>
 
-<section class="section" id="bottleneck">
-  <h2>Trafficking isn’t a workflow issue. It’s a truth issue.</h2>
+<section class="section" id="inside-the-pain">
+  <h2>Inside the pain of launch day.</h2>
   <ul>
-    <li>Specs get missed</li>
-    <li>Tags break attribution</li>
-    <li>Rework kills velocity</li>
+    <li>Specs get missed and files bounce back</li>
+    <li>Tags break attribution before you even go live</li>
+    <li>Endless rework kills velocity</li>
     <li>Delay means lost revenue</li>
   </ul>
   <blockquote>Without Dataraiils, you don’t just risk delay—you lose the data trail.</blockquote>
@@ -183,17 +185,13 @@
   </ol>
 </section>
 
-<section class="section" id="live-ops">
-  <h2>Live from the field.</h2>
+<section class="section" id="proof">
+  <h2>Proof it works.</h2>
   <ul>
     <li>“Campaign X prepped in 2m 13s — 0 tags failed”</li>
     <li>“Trafficking Sheet auto-exported to CM360 — 7 assets”</li>
     <li>“Saved 12.3 hours on Campaign Z – PHM Team”</li>
   </ul>
-</section>
-
-<section class="section" id="testimonial">
-  <h2>Trusted by the people who can’t afford to get it wrong.</h2>
   <blockquote>“This saved us 15 hours per campaign. And 15 headaches.”<br>— Senior Ad Ops Lead, Top 10 Pharma Agency</blockquote>
 </section>
 
@@ -203,6 +201,64 @@
   <a href="#" class="button-primary">Book a Demo — Go Live in 2 Days</a>
   <a href="#" class="button-secondary">Talk to Product</a>
   <a href="#" class="button-secondary">Start Using Dataraiils</a>
+</section>
+
+<section class="section" id="faq">
+  <h2>Frequently Asked Questions</h2>
+  <div class="faq-item">
+    <h3>What is Dataraiils?</h3>
+    <p>An AI platform that automates creative trafficking so your campaigns launch correctly.</p>
+  </div>
+  <div class="faq-item">
+    <h3>How does it improve trafficking?</h3>
+    <p>By auto-tagging, validating specs, and packaging assets for ad servers.</p>
+  </div>
+  <div class="faq-item">
+    <h3>Does it work with my ad server?</h3>
+    <p>Yes, Dataraiils exports launch packs for major ad servers like CM360.</p>
+  </div>
+  <div class="faq-item">
+    <h3>How long does onboarding take?</h3>
+    <p>Most teams are live in under two days.</p>
+  </div>
+  <div class="faq-item">
+    <h3>Can I try it for free?</h3>
+    <p>We offer pilot programs so you can prove value before committing.</p>
+  </div>
+  <div class="faq-item">
+    <h3>What file types are supported?</h3>
+    <p>Common display, video, and social ad formats are accepted.</p>
+  </div>
+  <div class="faq-item">
+    <h3>Does it handle tag validation?</h3>
+    <p>Yes, tags are scanned to ensure tracking works before launch.</p>
+  </div>
+  <div class="faq-item">
+    <h3>Is my data secure?</h3>
+    <p>Your assets are processed securely and never shared with third parties.</p>
+  </div>
+  <div class="faq-item">
+    <h3>Can the AI learn our taxonomy?</h3>
+    <p>Dataraiils adapts to custom naming conventions and taxonomies.</p>
+  </div>
+  <div class="faq-item">
+    <h3>Do you integrate with workflow tools?</h3>
+    <p>Yes, we connect to popular project management and storage platforms.</p>
+  </div>
+  <div class="faq-item">
+    <h3>How do I get support?</h3>
+    <p>Reach us anytime at hello@dataraiils.ai or through the contact form below.</p>
+  </div>
+</section>
+
+<section class="section" id="contact">
+  <h2>Contact Us</h2>
+  <form action="mailto:hello@dataraiils.ai" method="post" enctype="text/plain">
+    <label>Name<br><input type="text" name="name" required></label><br>
+    <label>Email<br><input type="email" name="email" required></label><br>
+    <label>Message<br><textarea name="message" rows="4" required></textarea></label><br>
+    <button type="submit" class="button-primary">Send</button>
+  </form>
 </section>
 
 <footer>


### PR DESCRIPTION
## Summary
- add navigation links and sections for Inside the Pain, Proof, FAQ, and Contact
- consolidate live ops and testimonial content into a unified Proof section
- introduce 11-question FAQ and a basic contact form

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893ef8849308329a67cbe815920f385