### PR TITLE
Revamp hero section with updated copy and styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,101 +31,24 @@
   </nav>
 </header>
 
-<section class="hero" style="position: relative; min-height: 100vh; overflow: hidden;">
-  <!-- Background Image -->
-  <img 
-    src="assets/images/dataraiils-ai-trafficking-automation-hero-sailboat-calm-clarity.png" 
-    alt="Hero background showing sailboat left, open sky right" 
-    style="
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      object-position: left center;
-      z-index: 0;
-      filter: brightness(0.95);
-    "
-    loading="lazy"
-  />
-
-  <!-- Vignette -->
-  <div style="
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: 60%;
-    height: 100%;
-    background: radial-gradient(circle at 75% center, rgba(27,27,31,0.08), rgba(27,27,31,0));
-    z-index: 1;
-    pointer-events: none;
-  "></div>
-
-  <!-- CTA Glow Zone -->
-  <div style="
-    position: absolute;
-    bottom: 15%;
-    left: 5vw;
-    width: 500px;
-    height: 120px;
-    background-color: rgba(243, 91, 37, 0.08); /* #F35B25 tint */
-    filter: blur(40px);
-    z-index: 1;
-    border-radius: 999px;
-    pointer-events: none;
-  "></div>
-
-  <!-- Text Content -->
-  <div style="
-    position: relative;
-    z-index: 2;
-    padding-left: 5vw;
-    max-width: 500px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    height: 100%;
-  ">
-    <h1 style="
-      font-family: 'Inter', sans-serif;
-      font-size: 48px;
-      font-weight: 700;
-      line-height: 1.2;
-      margin-bottom: 16px;
-    ">
-      Your campaign isn't live until your data is.
-    </h1>
-    <p style="
-      font-family: 'Inter', sans-serif;
-      font-size: 16px;
-      font-weight: 400;
-      margin-bottom: 28px;
-    ">
-      Dataraiils automates the final mile of creative ops—so your launch is real.
-    </p>
-    <a 
-      href="#how-it-works" 
-      class="button-primary" 
-      style="
-        display: inline-block;
-        padding: 12px 28px;
-        border-radius: 999px;
-        background-color: #9605DF;
-        color: #FFFFFF;
-        font-size: 16px;
-        font-weight: 500;
-        text-align: center;
-        transition: background-color 0.2s ease-in-out;
-        max-width: fit-content;
-      "
-      onmouseover="this.style.backgroundColor='#7E04B9'"
-      onmouseout="this.style.backgroundColor='#9605DF'"
-    >
-      See It In Action 
-    </a>
-  </div>
-</section>
+  <section class="hero">
+    <img
+      src="assets/images/dataraiils-ai-trafficking-automation-hero-sailboat-calm-clarity.png"
+      alt="Hero background showing sailboat left, open sky right"
+      class="hero-bg"
+      loading="lazy"
+    />
+    <div class="hero-vignette"></div>
+    <div class="hero-content">
+      <h1>Burn the spreadsheet.<br>Launch faster. Tag smarter. Track everything.</h1>
+      <h2>Dataraiils turns chaos into clarity — auto-tag, validate, and launch creative with zero bottlenecks.</h2>
+      <p class="hero-trust">Built for ad ops. Trusted by top AORs.</p>
+      <div class="hero-cta">
+        <a href="#demo" class="button-primary">See It in Action</a>
+        <a href="#demo" class="button-secondary">Book a Demo</a>
+      </div>
+    </div>
+  </section>
 
 <section class="section" id="inside-the-pain">
   <h2>Inside the pain of launch day.</h2>

--- a/style.css
+++ b/style.css
@@ -97,10 +97,12 @@ blockquote {
   border: none;
   border-radius: 999px;
   cursor: pointer;
-  transition: background-color 0.2s ease-in-out;
+  transition: background-color 0.2s ease-in-out, transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 }
 .button-primary:hover {
   background-color: #7E04B9;
+  transform: scale(1.03);
+  box-shadow: 0 0 8px rgba(150, 5, 223, 0.4);
 }
 .button-secondary {
   background: none;
@@ -117,27 +119,64 @@ blockquote {
 .hero {
   position: relative;
   min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
   overflow: hidden;
-}
-.hero-content {
-  position: relative;
-  z-index: 2;
-  max-width: 600px;
-  padding: 80px 24px;
+  color: #1B1B1F;
 }
 .hero-bg {
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
-  height: 120%;
+  height: 100%;
   object-fit: cover;
   object-position: left center;
-  opacity: 0.3;
   z-index: 0;
+}
+.hero-vignette {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 60%;
+  height: 100%;
+  background: radial-gradient(circle at 75% center, rgba(27,27,31,0.15), rgba(27,27,31,0));
+  z-index: 1;
+  pointer-events: none;
+}
+.hero-content {
+  position: relative;
+  z-index: 2;
+  max-width: 500px;
+  padding: 0 5vw;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 100vh;
+}
+.hero h1 {
+  font-size: 60px;
+  font-weight: 700;
+  line-height: 1.1;
+  margin-bottom: 16px;
+}
+.hero h2 {
+  font-family: 'Maison Neue', 'Inter', sans-serif;
+  font-size: 20px;
+  font-weight: 400;
+  line-height: 1.4;
+}
+.hero-trust {
+  font-family: 'Maison Neue', 'Inter', sans-serif;
+  font-size: 18px;
+  margin-top: 12px;
+}
+.hero-cta {
+  margin-top: 28px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+.hero-cta .button-secondary {
+  margin-left: 0;
 }
 
 /* Animations */
@@ -171,6 +210,24 @@ footer {
     .hero-content {
       padding: 40px 24px;
       max-width: 100%;
+      min-height: 100vh;
+    }
+    .hero h1 {
+      font-size: 36px;
+    }
+    .hero h2 {
+      font-size: 18px;
+    }
+    .hero-cta {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 16px;
+    }
+    .hero-cta .button-primary,
+    .hero-cta .button-secondary {
+      width: 100%;
+      margin-left: 0;
+      text-align: center;
     }
     .nav-bar {
       flex-direction: row;


### PR DESCRIPTION
## Summary
- refresh hero copy with new headline, subhead, and CTAs
- implement vignette-backed hero layout with responsive flex and button hover effects

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893f42d54548329a9e278f37a401df4