### PR TITLE
Revise hero section copy and CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,13 +40,12 @@
     />
     <div class="hero-vignette"></div>
     <div class="hero-content">
-      <h1>Burn the spreadsheet.<br>Launch faster. Tag smarter. Track everything.</h1>
-      <h2>Dataraiils turns chaos into clarity — auto-tag, validate, and launch creative with zero bottlenecks.</h2>
-      <p class="hero-trust">Built for ad ops. Trusted by top AORs.</p>
+      <h1>Trafficking shouldn't take 15 days.</h1>
+      <h2>Dataraiils replaces manual chaos with smart automation — tag, QA, and launch in 2.</h2>
       <div class="hero-cta">
-        <a href="#demo" class="button-primary">See It in Action</a>
-        <a href="#demo" class="button-secondary">Book a Demo</a>
+        <a href="#demo" class="button-primary">Kill the bottleneck</a>
       </div>
+      <p class="hero-subtext">Built inside real campaign pain. Not in a lab.</p>
     </div>
   </section>
 

--- a/style.css
+++ b/style.css
@@ -164,7 +164,7 @@ blockquote {
   font-weight: 400;
   line-height: 1.4;
 }
-.hero-trust {
+.hero-subtext {
   font-family: 'Maison Neue', 'Inter', sans-serif;
   font-size: 18px;
   margin-top: 12px;


### PR DESCRIPTION
## Summary
- Rewrite hero headline to emphasize faster trafficking cycles.
- Clarify subhead with explicit automation benefits and shorten CTA section to a single action.
- Add hero-subtext styling to support new tagline beneath the CTA.

## Testing
- `npx prettier --check index.html style.css` (warn: code style issues found)
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893f77001108329abd399e9f29d8e1f