### PR TITLE
Rebuild three-step process section

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,13 +100,29 @@
   </ul>
 </section>
 
-<section class="section" id="how-it-works">
-  <h2>Three steps. One clean launch.</h2>
-  <ol>
-    <li>Drop your assets</li>
-    <li>Dataraiils tags and validates</li>
-    <li>Download your launch pack</li>
-  </ol>
+<section class="three-step-section" id="how-it-works">
+  <h2 class="section-headline">Three steps. One clean launch.</h2>
+  <p class="section-subhead">This isn’t a platform tour. It’s the full handoff—done in three clicks.</p>
+
+  <div class="three-step-process">
+    <div class="step-card">
+      <img src="assets/images/function-ui-icon-upload-asset-dataraiils-purple.png" alt="Upload icon – purple cloud with upward arrow" />
+      <h3>Drop your assets</h3>
+      <p>Upload raw files — any format, from anywhere.</p>
+    </div>
+
+    <div class="step-card">
+      <img src="assets/images/function-ui-icon-tag-and-validate-dataraiils-purple.png" alt="Tag and validation icon – purple label with magnifying glass and check mark" />
+      <h3>Dataraiils tags and validates</h3>
+      <p>AI applies naming, specs, and taxonomy — instantly.</p>
+    </div>
+
+    <div class="step-card">
+      <img src="assets/images/function-ui-icon-download-package-dataraiils-purple.png" alt="Download icon – purple folder with downward arrow" />
+      <h3>Download your launch pack</h3>
+      <p>Get trafficking sheets, audit logs, and previews — done.</p>
+    </div>
+  </div>
 </section>
 
 <section class="section" id="proof">
@@ -197,7 +213,7 @@
 <script>
   // Optional scroll animation support
     const reveal = () => {
-      const elements = document.querySelectorAll('.fade-in');
+      const elements = document.querySelectorAll('.fade-in, .step-card');
       const triggerBottom = window.innerHeight * 0.9;
       elements.forEach(el => {
         const boxTop = el.getBoundingClientRect().top;

--- a/style.css
+++ b/style.css
@@ -120,6 +120,90 @@ blockquote {
   font-size: 16px;
 }
 
+/* Three Step Process Section */
+.section-headline {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-size: 36px;
+  text-align: center;
+  color: #1B1B1F; /* Navy Ink */
+  margin-bottom: 16px;
+}
+
+.section-subhead {
+  font-family: 'Inter', sans-serif;
+  font-weight: 400;
+  font-size: 18px;
+  text-align: center;
+  color: #4B4B50; /* Slate Fog */
+  max-width: 600px;
+  margin: 0 auto 48px auto;
+}
+
+.three-step-process {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 80px 0;
+  flex-wrap: wrap;
+}
+
+.step-card {
+  flex: 1 1 30%;
+  max-width: 380px;
+  padding: 32px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: transparent;
+  min-height: 320px;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: all 0.4s ease;
+}
+
+.step-card img {
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+  margin-bottom: 24px;
+}
+
+.step-card h3 {
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: 18px;
+  color: #1B1B1F;
+  margin-bottom: 12px;
+}
+
+.step-card p {
+  font-family: 'Inter', sans-serif;
+  font-weight: 400;
+  font-size: 16px;
+  color: #4B4B50;
+  max-width: 300px;
+}
+
+.step-card.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media screen and (max-width: 768px) {
+  .three-step-process {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .step-card {
+    max-width: 100%;
+    margin-bottom: 48px;
+  }
+}
+
 /* Nav */
 .nav-bar {
   display: flex;


### PR DESCRIPTION
## Summary
- replace "how it works" section with three-step process cards and icons
- style new section with responsive layout and scroll reveal animation
- include step cards in scroll reveal JS

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894b0de89588329b931e91e64db6b97