### PR TITLE
Reorder how-it-works section before ship

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,27 +80,6 @@
     </div>
   </section>
 
-<section class="section launch-section" id="ship">
-  <div class="launch-wrapper">
-    <div class="launch-copy">
-      <h2>We didn’t build this for marketers.</h2>
-      <p>
-        We built it for the ones launching at 11:59 PM.<br>
-        The ones renaming files mid-flight.<br>
-        Manually updating spec sheets. Again.<br>
-        No dashboards. No fluff. Just launch.
-      </p>
-    </div>
-    <div class="launch-quote">
-      <div class="quote-bg" aria-hidden="true" role="presentation"></div>
-      <div class="quote-card">
-        <p>“This saved us 15 hours per campaign. And 15 headaches.”</p>
-        <p class="quote-attribution">— Senior Ad Ops Lead, Top 10 Pharma Agency</p>
-      </div>
-    </div>
-  </div>
-</section>
-
 <section class="three-step-process" id="how-it-works">
   <h2 class="section-headline">Three steps. One clean launch.</h2>
   <p class="section-subhead">This isn’t a platform tour. It’s the full handoff—done in three clicks.</p>
@@ -121,6 +100,27 @@
     <img src="assets/images/function-ui-icon-download-package-dataraiils-purple.svg" alt="Download icon – purple folder with downward arrow" />
     <h3>Download your launch pack</h3>
     <p>Get trafficking sheets, audit logs, and previews — done.</p>
+  </div>
+</section>
+
+<section class="section launch-section" id="ship">
+  <div class="launch-wrapper">
+    <div class="launch-copy">
+      <h2>We didn’t build this for marketers.</h2>
+      <p>
+        We built it for the ones launching at 11:59 PM.<br>
+        The ones renaming files mid-flight.<br>
+        Manually updating spec sheets. Again.<br>
+        No dashboards. No fluff. Just launch.
+      </p>
+    </div>
+    <div class="launch-quote">
+      <div class="quote-bg" aria-hidden="true" role="presentation"></div>
+      <div class="quote-card">
+        <p>“This saved us 15 hours per campaign. And 15 headaches.”</p>
+        <p class="quote-attribution">— Senior Ad Ops Lead, Top 10 Pharma Agency</p>
+      </div>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- move the "three-step-process" section ahead of the "launch" section on the landing page so the "How It Works" content appears before "Ship".

## Testing
- `python -m http.server 8000 &`
- `curl -s http://localhost:8000/index.html | grep -n "three-step-process" -n`
- `curl -s http://localhost:8000/index.html | grep -n "launch-section" -n`
- `curl -s http://localhost:8000/index.html | grep -n "#how-it-works" -n`


------
https://chatgpt.com/codex/tasks/task_e_6894cab8756883298093551ad1e1c63d