### PR TITLE
Add accordion FAQ and responsive footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,51 +147,109 @@
   <a href="#" class="button-secondary">Start Using Dataraiils</a>
 </section>
 
-<section class="section" id="faq">
-  <h2>Frequently Asked Questions</h2>
-  <div class="faq-item">
-    <h3>What is Dataraiils?</h3>
-    <p>An AI platform that automates creative trafficking so your campaigns launch correctly.</p>
-  </div>
-  <div class="faq-item">
-    <h3>How does it improve trafficking?</h3>
-    <p>By auto-tagging, validating specs, and packaging assets for ad servers.</p>
-  </div>
-  <div class="faq-item">
-    <h3>Does it work with my ad server?</h3>
-    <p>Yes, Dataraiils exports launch packs for major ad servers like CM360.</p>
-  </div>
-  <div class="faq-item">
-    <h3>How long does onboarding take?</h3>
-    <p>Most teams are live in under two days.</p>
-  </div>
-  <div class="faq-item">
-    <h3>Can I try it for free?</h3>
-    <p>We offer pilot programs so you can prove value before committing.</p>
-  </div>
-  <div class="faq-item">
-    <h3>What file types are supported?</h3>
-    <p>Common display, video, and social ad formats are accepted.</p>
-  </div>
-  <div class="faq-item">
-    <h3>Does it handle tag validation?</h3>
-    <p>Yes, tags are scanned to ensure tracking works before launch.</p>
-  </div>
-  <div class="faq-item">
-    <h3>Is my data secure?</h3>
-    <p>Your assets are processed securely and never shared with third parties.</p>
-  </div>
-  <div class="faq-item">
-    <h3>Can the AI learn our taxonomy?</h3>
-    <p>Dataraiils adapts to custom naming conventions and taxonomies.</p>
-  </div>
-  <div class="faq-item">
-    <h3>Do you integrate with workflow tools?</h3>
-    <p>Yes, we connect to popular project management and storage platforms.</p>
-  </div>
-  <div class="faq-item">
-    <h3>How do I get support?</h3>
-    <p>Reach us anytime at hello@dataraiils.ai or through the contact form below.</p>
+<section id="faq" class="section faq-block">
+  <h2>You’ve got questions. We work in answers.</h2>
+  <p class="faq-intro">FAQ – Dataraiils (11 Questions)</p>
+  <div class="faq-grid">
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>How fast can we go live with Dataraiils?</span>
+        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+      </button>
+      <div class="faq-answer">
+        <p>Most teams go live in under 2 days. No IT lift required.</p>
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>Does it integrate with our trafficking tools (e.g. CM360, SharePoint)?</span>
+        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+      </button>
+      <div class="faq-answer">
+        <p>Yes — Dataraiils exports trafficking sheets pre-formatted for CM360, DDM,  Meta, YouTube, DV360, and more.</p>
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>What kind of files can I upload?</span>
+        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+      </button>
+      <div class="faq-answer">
+        <p>Video, display, audio, HTML5, or static — if it ships, we take it.</p>
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>Can we override or edit AI-suggested tags?</span>
+        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+      </button>
+      <div class="faq-answer">
+        <p>Yes. Operators stay in control — you can review, accept, or adjust every field.</p>
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>Does it support multiple brands or campaigns at once?</span>
+        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+      </button>
+      <div class="faq-answer">
+        <p>Absolutely. Dataraiils is built for high-volume, multi-brand trafficking at scale.</p>
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>Can this help with version control or audit trails?</span>
+        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+      </button>
+      <div class="faq-answer">
+        <p>Yes. Everything is timestamped, versioned, and exportable for audit review.</p>
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>How does Dataraiils ensure compliance with platform specs?</span>
+        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+      </button>
+      <div class="faq-answer">
+        <p>It applies platform-specific rules for naming, dimensions, duration, safe zones, and more — automatically.</p>
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>Is this just another DAM or asset management tool?</span>
+        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+      </button>
+      <div class="faq-answer">
+        <p>No. Dataraiils doesn’t store files — it preps them for launch.</p>
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>Do I need to train my team?</span>
+        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+      </button>
+      <div class="faq-answer">
+        <p>If they know how to upload a file and click “Download,” they’re good.</p>
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>How is this different from full-stack creative platforms?</span>
+        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+      </button>
+      <div class="faq-answer">
+        <p>Those platforms try to do everything. Dataraiils does one thing — trafficking — brilliantly.</p>
+      </div>
+    </div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>What’s your pricing model?</span>
+        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+      </button>
+      <div class="faq-answer">
+        <p>Seat-based SaaS, with optional add-ons. No bloated enterprise contracts.</p>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -205,13 +263,27 @@
   </form>
 </section>
 
-<footer>
-  <p>
-    © 2025 dataraiils.ai — 
-    <a href="privacy.html">Privacy</a> | 
-    <a href="terms.html">Terms</a> | 
-    <a href="mailto:hello@dataraiils.ai">Contact</a>
-  </p>
+<footer class="site-footer">
+  <div class="footer-grid">
+    <div class="footer-left">
+      <img src="assets/images/dataraiils-logo.png" alt="Dataraiils Logo" class="footer-logo">
+      <p class="footer-tagline">Made by ops. For ops.</p>
+    </div>
+    <nav class="footer-nav">
+      <a href="#product">Product</a>
+      <a href="#how-it-works">How It Works</a>
+      <a href="#inside-the-pain">Inside the Pain</a>
+      <a href="#proof">Proof</a>
+      <a href="#faq">FAQ</a>
+      <a href="#contact">Contact</a>
+    </nav>
+    <div class="footer-legal">
+      <p>© 2025 dataraiils.ai</p>
+      <a href="privacy.html">Privacy</a>
+      <a href="terms.html">Terms</a>
+      <a href="https://www.linkedin.com/company/dataraiils" target="_blank" rel="noopener">LinkedIn</a>
+    </div>
+  </div>
 </footer>
 
 <script>
@@ -231,6 +303,15 @@
     const navMenu = document.getElementById('nav-menu');
     navToggle.addEventListener('click', () => {
       navMenu.classList.toggle('open');
+    });
+
+    document.querySelectorAll('.faq-question').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const item = btn.parentElement;
+        item.classList.toggle('open');
+        const expanded = btn.getAttribute('aria-expanded') === 'true';
+        btn.setAttribute('aria-expanded', !expanded);
+      });
     });
   </script>
 

--- a/style.css
+++ b/style.css
@@ -499,13 +499,91 @@ blockquote {
   transform: translateY(0);
 }
 
+/* FAQ */
+#faq {
+  background-color: #FFFFFF;
+}
+.faq-intro {
+  margin-bottom: 32px;
+}
+.faq-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  max-width: 960px;
+  margin: 0 auto;
+}
+.faq-item {
+  border-bottom: 1px solid #E5E7EB;
+  padding: 16px 0;
+}
+.faq-question {
+  font-size: 18px;
+  font-weight: 600;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+.faq-icon {
+  transition: transform 0.3s ease;
+}
+.faq-answer {
+  display: none;
+  margin-top: 8px;
+  font-size: 16px;
+}
+.faq-item.open .faq-answer {
+  display: block;
+}
+.faq-item.open .faq-icon {
+  transform: rotate(180deg);
+}
+
 /* Footer */
-footer {
-  background-color: #FAFAFA;
+.site-footer {
+  background-color: #F5F5F5;
   padding: 48px 24px;
-  text-align: center;
   font-size: 14px;
-  color: #888;
+  color: #1B1B1F;
+}
+.footer-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 24px;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+.footer-left img {
+  height: 32px;
+}
+.footer-tagline {
+  margin-top: 8px;
+}
+.footer-nav {
+  display: flex;
+  flex-direction: column;
+}
+.footer-nav a,
+.footer-legal a {
+  color: inherit;
+  text-decoration: none;
+  margin-bottom: 8px;
+}
+.footer-nav a:hover,
+.footer-legal a:hover {
+  text-decoration: underline;
+}
+.footer-legal {
+  text-align: right;
+}
+.footer-legal p {
+  margin-bottom: 8px;
 }
 
 /* Media Queries */
@@ -583,5 +661,18 @@ footer {
     .button-secondary {
       display: block;
       margin: 12px 0 0;
+    }
+    .faq-grid {
+      grid-template-columns: 1fr;
+    }
+    .footer-grid {
+      grid-template-columns: 1fr;
+      text-align: center;
+    }
+    .footer-legal {
+      text-align: center;
+    }
+    .footer-nav {
+      align-items: center;
     }
   }


### PR DESCRIPTION
## Summary
- Replace FAQ section with two-column accordion and caret icons
- Introduce new three-column footer with navigation and legal links
- Add responsive styles for FAQ and footer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894d9fe34f883298baccf1f4490b841