### PR TITLE
Move demo section after FAQ

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,14 +139,6 @@
   </div>
 </section>
 
-<section class="section text-center" id="demo">
-  <h2>You fixed media. You nailed measurement. But launch is still chaos.</h2>
-  <p>The spreadsheet’s still winning. Dataraiils ends that.</p>
-  <a href="#" class="button-primary">Book a Demo — Go Live in 2 Days</a>
-  <a href="#" class="button-secondary">Talk to Product</a>
-  <a href="#" class="button-secondary">Start Using Dataraiils</a>
-</section>
-
 <section id="faq" class="section faq-block">
   <h2>You’ve got questions. We work in answers.</h2>
   <p class="faq-intro">FAQ – Dataraiils (11 Questions)</p>
@@ -251,6 +243,14 @@
       </div>
     </div>
   </div>
+</section>
+
+<section class="section text-center" id="demo">
+  <h2>You fixed media. You nailed measurement. But launch is still chaos.</h2>
+  <p>The spreadsheet’s still winning. Dataraiils ends that.</p>
+  <a href="#" class="button-primary">Book a Demo — Go Live in 2 Days</a>
+  <a href="#" class="button-secondary">Talk to Product</a>
+  <a href="#" class="button-secondary">Start Using Dataraiils</a>
 </section>
 
 <section class="section" id="contact">


### PR DESCRIPTION
## Summary
- relocate demo CTA section to follow the FAQ and appear before contact/footer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894dd7390d0832984fd05408f3dea93