### PR TITLE
Revamp hero messaging and CTA styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,8 +40,8 @@
     <div class="hero-overlay"></div>
     <div class="hero-trails"></div>
     <div class="hero-content">
-      <h1 class="fade-in">Cut through the chaos. Chart a faster path.</h1>
-      <p class="lead fade-in delay-1">Dataraiils automates tagging, QA, and launch so you ship in two days.</p>
+      <h1 class="fade-in">Trafficking Sheets. Done in Minutes.</h1>
+      <p class="lead fade-in delay-1">Built for the people who ship.</p>
       <div class="hero-cta fade-in delay-2">
         <a href="#demo" class="button-primary">See how it works</a>
       </div>

--- a/style.css
+++ b/style.css
@@ -375,17 +375,18 @@ blockquote {
 .button-primary {
   background-color: #9605DF;
   color: #FFFFFF;
-  padding: 12px 24px;
-  font-size: 16px;
+  padding: 16px 32px;
+  font-size: 18px;
   font-weight: 700;
   border: none;
   border-radius: 999px;
   cursor: pointer;
-  transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out, transform 0.2s ease-in-out;
 }
 .button-primary:hover {
   background-color: #7E04B9;
   box-shadow: 0 0 8px rgba(150, 5, 223, 0.4);
+  transform: scale(1.05);
 }
 .button-primary:focus {
   outline: none;


### PR DESCRIPTION
## Summary
- Rewrite hero headline to emphasize quick trafficking sheet completion.
- Simplify subheadline to speak directly to shipping teams.
- Enhance primary CTA with brand purple, larger padding, and hover feedback.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894ea61f21083298ceca8429932768c