### PR TITLE
Add bold transition banners

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,9 +43,14 @@
       </div>
       <p class="hero-microproof fade-in delay-3">Trusted by top pharma AORs.</p>
     </div>
-  </section>
+    </section>
 
-  <section id="inside-the-pain" class="pain-section">
+    <div class="transition">
+      <hr>
+      <p>Burn the spreadsheet.</p>
+    </div>
+
+    <section id="inside-the-pain" class="pain-section">
     <div class="pain-wrapper">
       <h2>SLA: 10–15 days. That’s not a standard. That’s a red flag.</h2>
       <p>This wasn’t built in a lab. It was built in the middle of live campaigns.</p>
@@ -238,9 +243,14 @@
       </div>
     </div>
   </div>
-</section>
+  </section>
 
-<section class="section text-center" id="demo">
+  <div class="transition">
+    <hr>
+    <p>No more trafficking hell.</p>
+  </div>
+
+  <section class="section text-center" id="demo">
   <h2>You fixed media. You nailed measurement. But launch is still chaos.</h2>
   <p>The spreadsheet’s still winning. Dataraiils ends that.</p>
   <a href="#" class="button-primary">Book a Demo — Go Live in 2 Days</a>


### PR DESCRIPTION
## Summary
- add transition banner after hero with "Burn the spreadsheet"
- add late-page banner declaring "No more trafficking hell"
- keep "Built for the people who ship" tagline visible in hero

## Testing
- `npm test` *(fails: could not find a package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f4863d9c8329a43d8c9999e4b638