### PR TITLE
Animate step cards on scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,7 +289,11 @@
       const triggerBottom = window.innerHeight * 0.9;
       elements.forEach(el => {
         const boxTop = el.getBoundingClientRect().top;
-        if (boxTop < triggerBottom) el.classList.add('visible');
+        if (boxTop < triggerBottom) {
+          el.classList.add('visible');
+        } else {
+          el.classList.remove('visible');
+        }
       });
     };
     window.addEventListener('scroll', reveal);

--- a/style.css
+++ b/style.css
@@ -338,6 +338,9 @@ blockquote {
   display: flex;
   flex-direction: column;
   align-items: center;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: all 0.6s ease-out;
 }
 
 .step-card img {
@@ -361,6 +364,11 @@ blockquote {
   font-size: 16px;
   color: #4B4B50;
   max-width: 300px;
+}
+
+.step-card.visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 @media screen and (max-width: 768px) {


### PR DESCRIPTION
## Summary
- Hide three-step process cards by default and add transition-ready state
- Enable reveal() script to toggle `.visible` so cards animate into place

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f5c4ad448329b4b1c671aca79815