### PR TITLE
Hide decorative FAQ icons from screen readers

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>How fast can we go live with Dataraiils?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Most teams go live in under 2 days. No IT lift required.</p>
@@ -155,7 +155,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>Does it integrate with our trafficking tools (e.g. CM360, SharePoint)?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Yes — Dataraiils exports trafficking sheets pre-formatted for CM360, DDM,  Meta, YouTube, DV360, and more.</p>
@@ -164,7 +164,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>What kind of files can I upload?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Video, display, audio, HTML5, or static — if it ships, we take it.</p>
@@ -173,7 +173,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>Can we override or edit AI-suggested tags?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Yes. Operators stay in control — you can review, accept, or adjust every field.</p>
@@ -182,7 +182,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>Does it support multiple brands or campaigns at once?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Absolutely. Dataraiils is built for high-volume, multi-brand trafficking at scale.</p>
@@ -191,7 +191,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>Can this help with version control or audit trails?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Yes. Everything is timestamped, versioned, and exportable for audit review.</p>
@@ -200,7 +200,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>How does Dataraiils ensure compliance with platform specs?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>It applies platform-specific rules for naming, dimensions, duration, safe zones, and more — automatically.</p>
@@ -209,7 +209,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>Is this just another DAM or asset management tool?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>No. Dataraiils doesn’t store files — it preps them for launch.</p>
@@ -218,7 +218,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>Do I need to train my team?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>If they know how to upload a file and click “Download,” they’re good.</p>
@@ -227,7 +227,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>How is this different from full-stack creative platforms?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Those platforms try to do everything. Dataraiils does one thing — trafficking — brilliantly.</p>
@@ -236,7 +236,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>What’s your pricing model?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Seat-based SaaS, with optional add-ons. No bloated enterprise contracts.</p>


### PR DESCRIPTION
## Summary
- hide decorative FAQ icons from assistive tech by adding `aria-hidden="true"` and `focusable="false"`

## Testing
- `npx -y @axe-core/cli index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@axe-core%2fcli)*
- `npx -y pa11y index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/pa11y)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f5c9428c8329b67f11ff22c01c50