### PR TITLE
Mark decorative imagery as hidden from screen readers

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,9 +29,10 @@
   <section class="hero" id="product">
     <img
       src="assets/images/dataraiils-ai-trafficking-automation-hero-sailboat-calm-clarity.png"
-      alt="Sailboat in motion, symbolizing streamlined execution"
+      alt=""
       class="hero-bg"
       loading="lazy"
+      aria-hidden="true"
     />
     <div class="hero-overlay"></div>
     <div class="hero-trails"></div>
@@ -85,19 +86,19 @@
   <p class="section-subhead">This isn’t a platform tour. It’s the full handoff—done in three clicks.</p>
 
   <div class="step-card">
-    <img src="assets/images/function-ui-icon-upload-asset-dataraiils-purple.svg" alt="Upload icon – purple cloud with upward arrow" />
+    <img src="assets/images/function-ui-icon-upload-asset-dataraiils-purple.svg" alt="" aria-hidden="true" />
     <h3>Drop your assets</h3>
     <p>Upload raw files — any format, from anywhere.</p>
   </div>
 
   <div class="step-card">
-    <img src="assets/images/function-ui-icon-tag-and-validate-dataraiils-purple.svg" alt="Tag and validation icon – purple label with magnifying glass and check mark" />
+    <img src="assets/images/function-ui-icon-tag-and-validate-dataraiils-purple.svg" alt="" aria-hidden="true" />
     <h3>Dataraiils tags and validates</h3>
     <p>AI applies naming, specs, and taxonomy — instantly.</p>
   </div>
 
   <div class="step-card">
-    <img src="assets/images/function-ui-icon-download-package-dataraiils-purple.svg" alt="Download icon – purple folder with downward arrow" />
+    <img src="assets/images/function-ui-icon-download-package-dataraiils-purple.svg" alt="" aria-hidden="true" />
     <h3>Download your launch pack</h3>
     <p>Get trafficking sheets, audit logs, and previews — done.</p>
   </div>
@@ -146,7 +147,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>How fast can we go live with Dataraiils?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Most teams go live in under 2 days. No IT lift required.</p>
@@ -155,7 +156,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>Does it integrate with our trafficking tools (e.g. CM360, SharePoint)?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Yes — Dataraiils exports trafficking sheets pre-formatted for CM360, DDM,  Meta, YouTube, DV360, and more.</p>
@@ -164,7 +165,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>What kind of files can I upload?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Video, display, audio, HTML5, or static — if it ships, we take it.</p>
@@ -173,7 +174,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>Can we override or edit AI-suggested tags?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Yes. Operators stay in control — you can review, accept, or adjust every field.</p>
@@ -182,7 +183,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>Does it support multiple brands or campaigns at once?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Absolutely. Dataraiils is built for high-volume, multi-brand trafficking at scale.</p>
@@ -191,7 +192,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>Can this help with version control or audit trails?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Yes. Everything is timestamped, versioned, and exportable for audit review.</p>
@@ -200,7 +201,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>How does Dataraiils ensure compliance with platform specs?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>It applies platform-specific rules for naming, dimensions, duration, safe zones, and more — automatically.</p>
@@ -209,7 +210,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>Is this just another DAM or asset management tool?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>No. Dataraiils doesn’t store files — it preps them for launch.</p>
@@ -218,7 +219,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>Do I need to train my team?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>If they know how to upload a file and click “Download,” they’re good.</p>
@@ -227,7 +228,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>How is this different from full-stack creative platforms?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Those platforms try to do everything. Dataraiils does one thing — trafficking — brilliantly.</p>
@@ -236,7 +237,7 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>What’s your pricing model?</span>
-        <svg class="faq-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
+        <svg class="faq-icon" aria-hidden="true" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1"><path d="M3 4.5L6 7.5L9 4.5"/></svg>
       </button>
       <div class="faq-answer">
         <p>Seat-based SaaS, with optional add-ons. No bloated enterprise contracts.</p>


### PR DESCRIPTION
## Summary
- hide decorative hero image and step icons from assistive tech with empty `alt` text and `aria-hidden="true"`
- mark FAQ arrow SVGs as `aria-hidden` to prevent redundant announcements

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f5c1001083299feb111f3becbb99