### PR TITLE
refactor: introduce color tokens and improve contrast

### DIFF
--- a/COLOR_TOKENS.md
+++ b/COLOR_TOKENS.md
@@ -1,0 +1,22 @@
+# Color Tokens
+
+This project defines reusable color tokens in `style.css` under the `:root` selector.
+The table below lists each token, its hex value, and example contrast ratios checked
+with `scripts/contrast_check.py`.
+
+| Token | Hex | Description | Contrast vs White | Contrast vs `#F5F5F5` |
+|-------|-----|-------------|-------------------|-----------------------|
+| `--color-ink` | `#1B1B1F` | Primary text | 17.17 | 15.75 |
+| `--color-muted` | `#4B5563` | Muted text | 7.56 | 6.93 |
+| `--color-gray-500` | `#444444` | Blockquote text | 9.74 | 8.93 |
+| `--color-gray-600` | `#4B4B50` | Secondary headings | 8.67 | 7.95 |
+| `--color-brand` | `#9605DF` | Brand purple | 6.21 | 5.69 |
+| `--color-brand-dark` | `#7E04B9` | Brand hover | 8.06 | 7.39 |
+| `--color-brand-accent` | `#6D2EFF` | Accent borders | n/a | n/a |
+| `--color-white` | `#FFFFFF` | Base background | n/a | n/a |
+| `--color-bg-muted` | `#F5F5F5` | Muted background | n/a | n/a |
+| `--color-bg-light` | `#FAFAFA` | Light background | n/a | n/a |
+| `--color-border` | `#E5E7EB` | Border gray | n/a | n/a |
+| `--color-border-light` | `#EEEEEE` | Light border | n/a | n/a |
+
+*Contrast ratios use [WCAG 2.1](https://www.w3.org/TR/WCAG21/#contrast-minimum) formula.*

--- a/scripts/contrast_check.py
+++ b/scripts/contrast_check.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+from math import pow
+
+COLORS = {
+    'ink': '#1B1B1F',
+    'muted': '#4B5563',
+    'gray-500': '#444444',
+    'gray-600': '#4B4B50',
+    'brand': '#9605DF',
+    'brand-dark': '#7E04B9',
+    'white': '#FFFFFF',
+    'bg-muted': '#F5F5F5',
+    'bg-light': '#FAFAFA',
+}
+
+PAIRS = [
+    ('ink', 'white'),
+    ('ink', 'bg-muted'),
+    ('ink', 'bg-light'),
+    ('muted', 'white'),
+    ('muted', 'bg-muted'),
+    ('muted', 'bg-light'),
+    ('gray-500', 'white'),
+    ('gray-600', 'white'),
+    ('brand', 'white'),
+    ('white', 'brand'),
+    ('white', 'brand-dark'),
+]
+
+def luminance(rgb):
+    srgb=[]
+    for c in rgb:
+        c/=255
+        srgb.append(c/12.92 if c<=0.03928 else pow((c+0.055)/1.055,2.4))
+    r,g,b=srgb
+    return 0.2126*r+0.7152*g+0.0722*b
+
+def contrast_ratio(hex1,hex2):
+    def hex_to_rgb(h):
+        h=h.lstrip('#')
+        if len(h)==3:
+            h=''.join(c*2 for c in h)
+        return tuple(int(h[i:i+2],16) for i in (0,2,4))
+    lum1=luminance(hex_to_rgb(hex1))
+    lum2=luminance(hex_to_rgb(hex2))
+    lighter=max(lum1,lum2)
+    darker=min(lum1,lum2)
+    return (lighter+0.05)/(darker+0.05)
+
+if __name__ == '__main__':
+    for fg, bg in PAIRS:
+        ratio=contrast_ratio(COLORS[fg], COLORS[bg])
+        print(f"{fg} on {bg}: {ratio:.2f}")

--- a/style.css
+++ b/style.css
@@ -12,8 +12,8 @@ body {
   font-family: 'Inter', system-ui, sans-serif;
   font-size: 16px;
   line-height: 1.6;
-  color: #1B1B1F;
-  background-color: #FFFFFF;
+  color: var(--color-ink);
+  background-color: var(--color-white);
 }
 h1 {
   font-size: 48px;
@@ -45,15 +45,27 @@ ul, ol {
 }
 blockquote {
   font-style: italic;
-  color: #444;
+  color: var(--color-gray-500);
   margin: 24px 0;
   padding-left: 20px;
-  border-left: 3px solid #9605DF;
+  border-left: 3px solid var(--color-brand);
 }
 
 /* Layout Containers */
 :root {
   --gutter: 16px;
+  --color-ink: #1B1B1F;
+  --color-muted: #4B5563;
+  --color-gray-500: #444444;
+  --color-gray-600: #4B4B50;
+  --color-brand: #9605DF;
+  --color-brand-dark: #7E04B9;
+  --color-brand-accent: #6D2EFF;
+  --color-white: #FFFFFF;
+  --color-bg-muted: #F5F5F5;
+  --color-bg-light: #FAFAFA;
+  --color-border: #E5E7EB;
+  --color-border-light: #EEEEEE;
 }
 
 .layout-grid {
@@ -79,7 +91,7 @@ blockquote {
 
 /* Utility */
 .brand-purple {
-  color: #9605DF;
+  color: var(--color-brand);
 }
 
 /* Navigation */
@@ -88,22 +100,22 @@ blockquote {
   justify-content: space-between;
   align-items: center;
   padding: 20px var(--gutter);
-  background-color: #fff;
-  border-bottom: 1px solid #eee;
+  background-color: var(--color-white);
+  border-bottom: 1px solid var(--color-border-light);
   position: sticky;
   top: 0;
   z-index: 1000;
 }
 .nav-link {
   margin-left: 20px;
-  color: #1B1B1F;
+  color: var(--color-ink);
   text-decoration: none;
   font-weight: 500;
 }
 
 /* Section 1 - Pain */
 .pain-section {
-  background-color: #F5F5F5;
+  background-color: var(--color-bg-muted);
   padding: 80px 24px;
 }
 .pain-wrapper {
@@ -117,7 +129,7 @@ blockquote {
 }
 .transition hr {
   border: 0;
-  border-top: 1px solid #9605DF;
+  border-top: 1px solid var(--color-brand);
   margin-bottom: 16px;
 }
 .transition p {
@@ -127,7 +139,7 @@ blockquote {
 
 /* Section 2 - Cost */
 .cost-section {
-  background-color: #FAFAFA;
+  background-color: var(--color-bg-light);
   padding: 60px 24px;
 }
 .cost-wrapper {
@@ -144,7 +156,7 @@ blockquote {
   justify-content: space-between;
   align-items: baseline;
   padding: 24px 0;
-  border-bottom: 1px solid #E5E7EB;
+  border-bottom: 1px solid var(--color-border);
 }
 .stats-list li:last-child {
   border-bottom: none;
@@ -165,7 +177,7 @@ blockquote {
 
 /* Launch Section */
 .launch-section {
-  background-color: #FAFAFA;
+  background-color: var(--color-bg-light);
 }
 .launch-wrapper {
   display: flex;
@@ -180,20 +192,20 @@ blockquote {
 .launch-copy h2 {
   font-size: 36px;
   font-weight: 700;
-  color: #1B1B1F; /* Navy Ink */
+  color: var(--color-ink); /* Navy Ink */
   margin-bottom: 16px;
 }
 .launch-copy p {
   font-size: 18px;
   font-weight: 400;
-  color: #6B7280; /* Slate Fog */
+  color: var(--color-muted); /* Slate Fog */
   line-height: 1.6;
 }
 
 .launch-benefits {
   font-size: 18px;
   font-weight: 400;
-  color: #6B7280; /* Slate Fog */
+  color: var(--color-muted); /* Slate Fog */
   line-height: 1.6;
   padding-left: 1.2em;
   list-style-type: disc;
@@ -219,7 +231,7 @@ blockquote {
 }
 .quote-card {
   background: rgba(255, 255, 255, 0.85);
-  border-left: 4px solid #6D2EFF; /* Brand Purple */
+  border-left: 4px solid var(--color-brand-accent); /* Brand Purple */
   padding: 24px;
   max-width: 480px;
   box-shadow: 0 4px 12px rgba(0,0,0,0.05);
@@ -229,18 +241,18 @@ blockquote {
 .quote-card p {
   font-size: 20px;
   font-weight: 700;
-  color: #1B1B1F;
+  color: var(--color-ink);
 }
 .quote-card .quote-attribution {
   font-size: 14px;
   font-weight: 400;
-  color: #6B7280;
+  color: var(--color-muted);
   margin-top: 8px;
 }
 
 /* Proof Section */
 #proof {
-  background-color: #F5F5F5;
+  background-color: var(--color-bg-muted);
 }
 
 .proof-content {
@@ -266,15 +278,15 @@ blockquote {
 
 .proof-quote {
   flex: 1 1 60%;
-  border: 1px solid #E5E7EB;
-  border-left: 4px solid #9605DF;
+  border: 1px solid var(--color-border);
+  border-left: 4px solid var(--color-brand);
   padding: 24px;
-  background-color: #FFFFFF;
+  background-color: var(--color-white);
   max-width: 600px;
   font-size: 20px;
   font-weight: 700;
   font-style: normal;
-  color: #1B1B1F;
+  color: var(--color-ink);
   margin: 0;
 }
 
@@ -301,7 +313,7 @@ blockquote {
   font-family: 'Inter', sans-serif;
   font-weight: 700;
   font-size: 36px;
-  color: #1B1B1F;
+  color: var(--color-ink);
   margin-bottom: 16px;
 }
 
@@ -310,7 +322,7 @@ blockquote {
   font-family: 'Inter', sans-serif;
   font-weight: 400;
   font-size: 18px;
-  color: #4B4B50;
+  color: var(--color-gray-600);
   margin-bottom: 48px;
   max-width: 600px;
   margin-left: auto;
@@ -351,7 +363,7 @@ blockquote {
   font-family: 'Inter', sans-serif;
   font-weight: 600;
   font-size: 18px;
-  color: #1B1B1F;
+  color: var(--color-ink);
   margin-bottom: 12px;
 }
 
@@ -359,7 +371,7 @@ blockquote {
   font-family: 'Inter', sans-serif;
   font-weight: 400;
   font-size: 16px;
-  color: #4B4B50;
+  color: var(--color-gray-600);
   max-width: 300px;
 }
 
@@ -401,8 +413,8 @@ blockquote {
 
 /* Buttons */
 .button-primary {
-  background-color: #9605DF;
-  color: #FFFFFF;
+  background-color: var(--color-brand);
+  color: var(--color-white);
   padding: 16px 32px;
   font-size: 18px;
   font-weight: 700;
@@ -412,7 +424,7 @@ blockquote {
   transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out, transform 0.2s ease-in-out;
 }
 .button-primary:hover {
-  background-color: #7E04B9;
+  background-color: var(--color-brand-dark);
   box-shadow: 0 0 8px rgba(150, 5, 223, 0.4);
   transform: scale(1.05);
 }
@@ -422,7 +434,7 @@ blockquote {
 }
 .button-secondary {
   background: none;
-  color: #9605DF;
+  color: var(--color-brand);
   font-size: 16px;
   font-weight: 500;
   text-decoration: underline;
@@ -439,7 +451,7 @@ blockquote {
   grid-template-columns: repeat(12, 1fr);
   align-items: center;
   overflow: hidden;
-  color: #1B1B1F;
+  color: var(--color-ink);
 }
 .hero-bg {
   position: absolute;
@@ -500,13 +512,13 @@ blockquote {
   font-size: 20px;
   font-weight: 400;
   line-height: 1.5;
-  color: #6B7280;
+  color: var(--color-muted);
   margin-bottom: 24px;
 }
 .hero-microproof {
   font-size: 14px;
   font-weight: 500;
-  color: #6B7280;
+  color: var(--color-muted);
   margin-top: 0;
 }
 .hero-cta {
@@ -530,7 +542,7 @@ blockquote {
 
 /* FAQ */
 #faq {
-  background-color: #FFFFFF;
+  background-color: var(--color-white);
 }
 .faq-intro {
   margin-bottom: 32px;
@@ -543,7 +555,7 @@ blockquote {
   margin: 0 auto;
 }
 .faq-item {
-  border-bottom: 1px solid #E5E7EB;
+  border-bottom: 1px solid var(--color-border);
   padding: 16px 0;
 }
 .faq-question {
@@ -576,10 +588,10 @@ blockquote {
 
 /* Footer */
 .site-footer {
-  background-color: #F5F5F5;
+  background-color: var(--color-bg-muted);
   padding: 48px 24px;
   font-size: 14px;
-  color: #1B1B1F;
+  color: var(--color-ink);
 }
 .footer-grid {
   display: grid;


### PR DESCRIPTION
## Summary
- centralize palette with CSS color tokens
- darken muted text to meet WCAG AA contrast
- document tokens and contrast ratios

## Testing
- `python scripts/contrast_check.py`


------
https://chatgpt.com/codex/tasks/task_e_6894f5be92108329b77719679bd224be