### PR TITLE
style: update CTA buttons to brand purple

### DIFF
--- a/style.css
+++ b/style.css
@@ -430,14 +430,27 @@ blockquote {
   box-shadow: 0 0 0 3px rgba(150, 5, 223, 0.5);
 }
 .button-secondary {
-  background: none;
-  color: #9605DF;
-  font-size: 16px;
-  font-weight: 500;
-  text-decoration: underline;
+  background-color: #9605DF;
+  color: #FFFFFF;
+  padding: 16px 32px;
+  font-size: 18px;
+  font-weight: 700;
   border: none;
-  margin-left: 16px;
+  border-radius: 999px;
   cursor: pointer;
+  margin-left: 16px;
+  text-decoration: none;
+  transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out, transform 0.2s ease-in-out;
+  display: inline-block;
+}
+.button-secondary:hover {
+  background-color: #7E04B9;
+  box-shadow: 0 0 8px rgba(150, 5, 223, 0.4);
+  transform: scale(1.05);
+}
+.button-secondary:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(150, 5, 223, 0.5);
 }
 
 /* Hero Section */
@@ -614,7 +627,6 @@ blockquote {
   margin-bottom: 8px;
 }
 .nav-link:hover,
-.button-secondary:hover,
 .footer-nav a:hover,
 .footer-legal a:hover {
   color: #7E04B9;
@@ -622,7 +634,6 @@ blockquote {
 }
 
 .nav-link:focus-visible,
-.button-secondary:focus-visible,
 .footer-nav a:focus-visible,
 .footer-legal a:focus-visible {
   outline: var(--focus-outline);


### PR DESCRIPTION
## Summary
- restyle secondary CTAs with brand purple background and clear white text
- refine link hover/focus styles to isolate CTA behavior

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/dataraiils/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6894f7bf5e3883298735279a0b6a7d81