### PR TITLE
Increase hero background visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -496,7 +496,7 @@ blockquote {
   height: 100%;
   object-fit: cover;
   object-position: left center;
-  opacity: 0.08;
+  opacity: 0.5;
   z-index: 0;
 }
 .hero-overlay {
@@ -505,7 +505,7 @@ blockquote {
   left: 0;
   width: 100%;
   height: 100%;
-  background: radial-gradient(circle at center, rgba(0,0,0,0) 40%, rgba(0,0,0,0.08) 100%);
+  background: radial-gradient(circle at center, rgba(0,0,0,0) 40%, rgba(0,0,0,0) 100%);
   z-index: 1;
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- Increase `.hero-bg` opacity to 0.5 for clearer background image.
- Remove radial overlay dimming by setting gradient alpha to 0.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894fe08ab6c8329a265fbb294845c94