### PR TITLE
Improve FAQ accessibility with ARIA

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,144 +145,138 @@
   <p class="faq-intro">FAQ – Dataraiils (11 Questions)</p>
   <div class="faq-grid">
     <div class="faq-item">
-      <button class="faq-question" aria-expanded="false">
-        <span>How fast can we go live with Dataraiils?</span>
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>How fast can we go live with dataraiils?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Most teams go live in under 2 days. No IT lift required.</p>
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Does it integrate with our trafficking tools (e.g. CM360, SharePoint)?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Yes — Dataraiils exports trafficking sheets pre-formatted for CM360, DDM, Meta, YouTube, DV360, and more.</p>
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>What kind of files can I upload?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Video, display, audio, HTML5, or static — if it ships, we take it.</p>
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Can we override or edit AI-suggested tags?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Yes — you stay in control. The system suggests, you approve or change as needed.</p>
-  </div>
-</div>
-        <p>Yes. Operators stay in control — you can review, accept, or adjust every field.</p>
+      <button class="faq-question" id="faq-question-1" aria-expanded="false" aria-controls="faq-answer-1">
+        <span>How fast can we go live with dataraiils?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-1" role="region" aria-labelledby="faq-question-1" aria-hidden="true">
+        <p>Most teams go live in under 2 days. No IT lift required.</p>
       </div>
     </div>
-  <div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Does it support native brand or privacy ad tech?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Absolutely. Dataraiils is built for high-volume, multi-threaded trafficking at scale.</p>
-  </div>
-</div>
 
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Can I change the way version control works?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Yes. Everything is timestamped, versioned, and exportable for audit review.</p>
-  </div>
-</div>
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-2" aria-expanded="false" aria-controls="faq-answer-2">
+        <span>Does it integrate with our trafficking tools (e.g. CM360, SharePoint)?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-2" role="region" aria-labelledby="faq-question-2" aria-hidden="true">
+        <p>Yes — Dataraiils exports trafficking sheets pre-formatted for CM360, DDM, Meta, YouTube, DV360, and more.</p>
+      </div>
+    </div>
 
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Does it apply platform-specific rules?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Yes. It applies platform-specific rules for naming, dimensions, duration, safe zones, and more — automatically.</p>
-  </div>
-</div>
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-3" aria-expanded="false" aria-controls="faq-answer-3">
+        <span>What kind of files can I upload?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-3" role="region" aria-labelledby="faq-question-3" aria-hidden="true">
+        <p>Video, display, audio, HTML5, or static — if it ships, we take it.</p>
+      </div>
+    </div>
 
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Does Dataraiils support dark mode?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Yes. Dataraiils doesn’t start fires — it preps them for launch.</p>
-  </div>
-</div>
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-4" aria-expanded="false" aria-controls="faq-answer-4">
+        <span>Can we override or edit AI-suggested tags?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-4" role="region" aria-labelledby="faq-question-4" aria-hidden="true">
+        <p>Yes — you stay in control. The system suggests, you approve or change as needed.</p>
+      </div>
+    </div>
 
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Do I need to bring my IT team?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Nope. Drop the files in a folder and click 'Upload.' They're good.</p>
-  </div>
-</div>
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-5" aria-expanded="false" aria-controls="faq-answer-5">
+        <span>Does it support native brand or privacy ad tech?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-5" role="region" aria-labelledby="faq-question-5" aria-hidden="true">
+        <p>Absolutely. Dataraiils is built for high-volume, multi-threaded trafficking at scale.</p>
+      </div>
+    </div>
 
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Can it handle multi-brand platforms?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Yes. Brands. Sub-brands. Regions. Dataraiils does the thing — trafficking — brilliantly.</p>
-  </div>
-</div>
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-6" aria-expanded="false" aria-controls="faq-answer-6">
+        <span>Can I change the way version control works?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-6" role="region" aria-labelledby="faq-question-6" aria-hidden="true">
+        <p>Yes. Everything is timestamped, versioned, and exportable for audit review.</p>
+      </div>
+    </div>
 
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>What’s the pricing model?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Seat-based SaaS, with optional add-ons. No bloated enterprise contracts.</p>
-  </div>
-</div>
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-7" aria-expanded="false" aria-controls="faq-answer-7">
+        <span>Does it apply platform-specific rules?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-7" role="region" aria-labelledby="faq-question-7" aria-hidden="true">
+        <p>Yes. It applies platform-specific rules for naming, dimensions, duration, safe zones, and more — automatically.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-8" aria-expanded="false" aria-controls="faq-answer-8">
+        <span>Does Dataraiils support dark mode?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-8" role="region" aria-labelledby="faq-question-8" aria-hidden="true">
+        <p>Yes. Dataraiils doesn’t start fires — it preps them for launch.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-9" aria-expanded="false" aria-controls="faq-answer-9">
+        <span>Do I need to bring my IT team?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-9" role="region" aria-labelledby="faq-question-9" aria-hidden="true">
+        <p>Nope. Drop the files in a folder and click 'Upload.' They're good.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-10" aria-expanded="false" aria-controls="faq-answer-10">
+        <span>Can it handle multi-brand platforms?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-10" role="region" aria-labelledby="faq-question-10" aria-hidden="true">
+        <p>Yes. Brands. Sub-brands. Regions. Dataraiils does the thing — trafficking — brilliantly.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-11" aria-expanded="false" aria-controls="faq-answer-11">
+        <span>What’s the pricing model?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-11" role="region" aria-labelledby="faq-question-11" aria-hidden="true">
+        <p>Seat-based SaaS, with optional add-ons. No bloated enterprise contracts.</p>
+      </div>
     </div>
   </div>
-  </section>
+</section>
 
   <div class="transition">
     <hr>
@@ -347,9 +341,13 @@
     document.querySelectorAll('.faq-question').forEach(btn => {
       btn.addEventListener('click', () => {
         const item = btn.parentElement;
-        item.classList.toggle('open');
+        const answer = document.getElementById(btn.getAttribute('aria-controls'));
         const expanded = btn.getAttribute('aria-expanded') === 'true';
-        btn.setAttribute('aria-expanded', !expanded);
+        btn.setAttribute('aria-expanded', String(!expanded));
+        if (answer) {
+          answer.setAttribute('aria-hidden', expanded ? 'true' : 'false');
+        }
+        item.classList.toggle('open');
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- assign unique IDs to FAQ questions and answers with matching aria-controls/aria-labelledby
- mark answers as regions and hide them initially
- update FAQ toggle script to sync aria-expanded and aria-hidden

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894fdd6f45083298be4fc641ef7264b