### PR TITLE
Fix FAQ selector and cleanup structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,142 +147,136 @@
     <div class="faq-item">
       <button class="faq-question" aria-expanded="false">
         <span>How fast can we go live with Dataraiils?</span>
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>How fast can we go live with dataraiils?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Most teams go live in under 2 days. No IT lift required.</p>
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Does it integrate with our trafficking tools (e.g. CM360, SharePoint)?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Yes — Dataraiils exports trafficking sheets pre-formatted for CM360, DDM, Meta, YouTube, DV360, and more.</p>
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>What kind of files can I upload?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Video, display, audio, HTML5, or static — if it ships, we take it.</p>
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Can we override or edit AI-suggested tags?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Yes — you stay in control. The system suggests, you approve or change as needed.</p>
-  </div>
-</div>
-        <p>Yes. Operators stay in control — you can review, accept, or adjust every field.</p>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer">
+        <p>Most teams go live in under 2 days. No IT lift required.</p>
       </div>
     </div>
-  <div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Does it support native brand or privacy ad tech?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Absolutely. Dataraiils is built for high-volume, multi-threaded trafficking at scale.</p>
-  </div>
-</div>
 
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Can I change the way version control works?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Yes. Everything is timestamped, versioned, and exportable for audit review.</p>
-  </div>
-</div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>Does it integrate with our trafficking tools (e.g. CM360, SharePoint)?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer">
+        <p>Yes — Dataraiils exports trafficking sheets pre-formatted for CM360, DDM, Meta, YouTube, DV360, and more.</p>
+      </div>
+    </div>
 
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Does it apply platform-specific rules?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Yes. It applies platform-specific rules for naming, dimensions, duration, safe zones, and more — automatically.</p>
-  </div>
-</div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>What kind of files can I upload?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer">
+        <p>Video, display, audio, HTML5, or static — if it ships, we take it.</p>
+      </div>
+    </div>
 
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Does Dataraiils support dark mode?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Yes. Dataraiils doesn’t start fires — it preps them for launch.</p>
-  </div>
-</div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>Can we override or edit AI-suggested tags?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer">
+        <p>Yes — you stay in control. The system suggests, you approve or change as needed.</p>
+      </div>
+    </div>
 
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Do I need to bring my IT team?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Nope. Drop the files in a folder and click 'Upload.' They're good.</p>
-  </div>
-</div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>Does it support native brand or privacy ad tech?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer">
+        <p>Absolutely. Dataraiils is built for high-volume, multi-threaded trafficking at scale.</p>
+      </div>
+    </div>
 
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>Can it handle multi-brand platforms?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Yes. Brands. Sub-brands. Regions. Dataraiils does the thing — trafficking — brilliantly.</p>
-  </div>
-</div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>Can I change the way version control works?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer">
+        <p>Yes. Everything is timestamped, versioned, and exportable for audit review.</p>
+      </div>
+    </div>
 
-<div class="faq-item">
-  <button class="faq-question" aria-expanded="false">
-    <span>What’s the pricing model?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer">
-    <p>Seat-based SaaS, with optional add-ons. No bloated enterprise contracts.</p>
-  </div>
-</div>
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>Does it apply platform-specific rules?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer">
+        <p>Yes. It applies platform-specific rules for naming, dimensions, duration, safe zones, and more — automatically.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>Does Dataraiils support dark mode?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer">
+        <p>Yes. Dataraiils doesn’t start fires — it preps them for launch.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>Do I need to bring my IT team?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer">
+        <p>Nope. Drop the files in a folder and click 'Upload.' They're good.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>Can it handle multi-brand platforms?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer">
+        <p>Yes. Brands. Sub-brands. Regions. Dataraiils does the thing — trafficking — brilliantly.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" aria-expanded="false">
+        <span>What’s the pricing model?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer">
+        <p>Seat-based SaaS, with optional add-ons. No bloated enterprise contracts.</p>
+      </div>
     </div>
   </div>
-  </section>
+</section>
 
   <div class="transition">
     <hr>
@@ -346,7 +340,7 @@
 
     document.querySelectorAll('.faq-question').forEach(btn => {
       btn.addEventListener('click', () => {
-        const item = btn.parentElement;
+        const item = btn.closest('.faq-item');
         item.classList.toggle('open');
         const expanded = btn.getAttribute('aria-expanded') === 'true';
         btn.setAttribute('aria-expanded', !expanded);


### PR DESCRIPTION
## Summary
- use `closest('.faq-item')` to ensure FAQ toggle finds the right container
- rebuild FAQ markup to remove nested `.faq-item` blocks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894fdd60cd08329999ecdcb91ddef58