### PR TITLE
Fix FAQ section structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,143 +146,133 @@
   <h2>You’ve got questions. We work in answers.</h2>
   <p class="faq-intro">FAQ – Dataraiils (11 Questions)</p>
   <div class="faq-grid">
-<div class="faq-item">
-  <button class="faq-question" id="faq-question-1" aria-expanded="false" aria-controls="faq-answer-1">
-    <span>How fast can we go live with Dataraiils?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer" id="faq-answer-1" role="region" aria-labelledby="faq-question-1" aria-hidden="true">
-    <p>Most teams go live in under 2 days. No IT lift required.</p>
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" id="faq-question-2" aria-expanded="false" aria-controls="faq-answer-2">
-    <span>Does it integrate with our trafficking tools (e.g. CM360, SharePoint)?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer" id="faq-answer-2" role="region" aria-labelledby="faq-question-2" aria-hidden="true">
-    <p>Yes – Dataraiils exports trafficking sheets pre-formatted for CM360, DDM, Meta, YouTube, DV360, and more.</p>
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" id="faq-question-3" aria-expanded="false" aria-controls="faq-answer-3">
-    <span>What kind of files can I upload?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer" id="faq-answer-3" role="region" aria-labelledby="faq-question-3" aria-hidden="true">
-    <p>Video, display, audio, HTML5, or static – if it ships, we take it.</p>
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" id="faq-question-4" aria-expanded="false" aria-controls="faq-answer-4">
-    <span>Can we override or edit AI-suggested tags?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer" id="faq-answer-4" role="region" aria-labelledby="faq-question-4" aria-hidden="true">
-    <p>Yes. Operators stay in control — you can review, accept, or adjust every field.</p>
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" id="faq-question-5" aria-expanded="false" aria-controls="faq-answer-5">
-    <span>Does it support native brand or privacy ad tech?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer" id="faq-answer-5" role="region" aria-labelledby="faq-question-5" aria-hidden="true">
-    <p>Absolutely. Dataraiils is built for high-volume, multi-threaded trafficking at scale.</p>
-  </div>
-</div>
-
     <div class="faq-item">
-<div class="faq-item">
-  <button class="faq-question" id="faq-question-6" aria-expanded="false" aria-controls="faq-answer-6">
-    <span>Can I change the way version control works?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer" id="faq-answer-6" role="region" aria-labelledby="faq-question-6" aria-hidden="true">
-    <p>Yes. Everything is timestamped, versioned, and exportable for audit review.</p>
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" id="faq-question-7" aria-expanded="false" aria-controls="faq-answer-7">
-    <span>Does it apply platform-specific rules?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer" id="faq-answer-7" role="region" aria-labelledby="faq-question-7" aria-hidden="true">
-    <p>Yes. It applies platform-specific rules for naming, dimensions, duration, safe zones, and more — automatically.</p>
-  </div>
-</div>
-
-<div class="faq-item">
-  <button class="faq-question" id="faq-question-8" aria-expanded="false" aria-controls="faq-answer-8">
-    <span>Does Dataraiils support dark mode?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer" id="faq-answer-8" role="region" aria-labelledby="faq-question-8" aria-hidden="true">
-    <p>Yes. Dataraiils doesn’t start fires — it preps them for launch.</p>
-  </div>
-</div>
-
+      <button class="faq-question" id="faq-question-1" aria-expanded="false" aria-controls="faq-answer-1">
+        <span>How fast can we go live with Dataraiils?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-1" role="region" aria-labelledby="faq-question-1" aria-hidden="true">
+        <p>Most teams go live in under 2 days. No IT lift required.</p>
       </div>
     </div>
-<div class="faq-answer" id="faq-answer-8" role="region" aria-labelledby="faq-question-8" aria-hidden="true">
-  <p>Yes. Dataraiils doesn’t start fires — it preps them for launch.</p>
-</div>
+
     <div class="faq-item">
-<div class="faq-item">
-  <button class="faq-question" id="faq-question-9" aria-expanded="false" aria-controls="faq-answer-9">
-    <span>Do I need to bring my IT team?</span>
-    <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
-      <path d="M3 4.5L6 7.5L9 4.5" />
-    </svg>
-  </button>
-  <div class="faq-answer" id="faq-answer-9" role="region" aria-labelledby="faq-question-9" aria-hidden="true">
-    <p>Nope. Drop the files in a folder and click 'Upload.' They’re good.</p>
-  </div>
-</div>
+      <button class="faq-question" id="faq-question-2" aria-expanded="false" aria-controls="faq-answer-2">
+        <span>Does it integrate with our trafficking tools (e.g. CM360, SharePoint)?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-2" role="region" aria-labelledby="faq-question-2" aria-hidden="true">
+        <p>Yes – Dataraiils exports trafficking sheets pre-formatted for CM360, DDM, Meta, YouTube, DV360, and more.</p>
+      </div>
+    </div>
+
     <div class="faq-item">
-      <button class="faq-question" aria-expanded="false">
+      <button class="faq-question" id="faq-question-3" aria-expanded="false" aria-controls="faq-answer-3">
+        <span>What kind of files can I upload?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-3" role="region" aria-labelledby="faq-question-3" aria-hidden="true">
+        <p>Video, display, audio, HTML5, or static – if it ships, we take it.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-4" aria-expanded="false" aria-controls="faq-answer-4">
+        <span>Can we override or edit AI-suggested tags?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-4" role="region" aria-labelledby="faq-question-4" aria-hidden="true">
+        <p>Yes. Operators stay in control — you can review, accept, or adjust every field.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-5" aria-expanded="false" aria-controls="faq-answer-5">
+        <span>Does it support native brand or privacy ad tech?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-5" role="region" aria-labelledby="faq-question-5" aria-hidden="true">
+        <p>Absolutely. Dataraiils is built for high-volume, multi-threaded trafficking at scale.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-6" aria-expanded="false" aria-controls="faq-answer-6">
+        <span>Can I change the way version control works?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-6" role="region" aria-labelledby="faq-question-6" aria-hidden="true">
+        <p>Yes. Everything is timestamped, versioned, and exportable for audit review.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-7" aria-expanded="false" aria-controls="faq-answer-7">
+        <span>Does it apply platform-specific rules?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-7" role="region" aria-labelledby="faq-question-7" aria-hidden="true">
+        <p>Yes. It applies platform-specific rules for naming, dimensions, duration, safe zones, and more — automatically.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-8" aria-expanded="false" aria-controls="faq-answer-8">
+        <span>Does Dataraiils support dark mode?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-8" role="region" aria-labelledby="faq-question-8" aria-hidden="true">
+        <p>Yes. Dataraiils doesn’t start fires — it preps them for launch.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
+      <button class="faq-question" id="faq-question-9" aria-expanded="false" aria-controls="faq-answer-9">
+        <span>Do I need to bring my IT team?</span>
+        <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
+          <path d="M3 4.5L6 7.5L9 4.5" />
+        </svg>
+      </button>
+      <div class="faq-answer" id="faq-answer-9" role="region" aria-labelledby="faq-question-9" aria-hidden="true">
+        <p>Nope. Drop the files in a folder and click 'Upload.' They’re good.</p>
+      </div>
+    </div>
+
+    <div class="faq-item">
       <button class="faq-question" id="faq-question-10" aria-expanded="false" aria-controls="faq-answer-10">
         <span>Can it handle multi-brand platforms?</span>
         <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
           <path d="M3 4.5L6 7.5L9 4.5" />
         </svg>
       </button>
-      <div class="faq-answer">
       <div class="faq-answer" id="faq-answer-10" role="region" aria-labelledby="faq-question-10" aria-hidden="true">
         <p>Yes. Brands. Sub-brands. Regions. Dataraiils does the thing — trafficking — brilliantly.</p>
       </div>
     </div>
 
     <div class="faq-item">
-      <button class="faq-question" aria-expanded="false">
       <button class="faq-question" id="faq-question-11" aria-expanded="false" aria-controls="faq-answer-11">
         <span>What’s the pricing model?</span>
         <svg class="faq-icon" aria-hidden="true" focusable="false" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1">
           <path d="M3 4.5L6 7.5L9 4.5" />
         </svg>
       </button>
-      <div class="faq-answer">
       <div class="faq-answer" id="faq-answer-11" role="region" aria-labelledby="faq-question-11" aria-hidden="true">
         <p>Seat-based SaaS, with optional add-ons. No bloated enterprise contracts.</p>
       </div>


### PR DESCRIPTION
## Summary
- Simplify FAQ markup by removing nested wrappers and stray answer blocks
- Ensure each question/answer pair has matching IDs
- Close the FAQ grid immediately after the last item

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68950384f4608329bc95fb9f408297f6