### PR TITLE
Fix FAQ toggle to use single item reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -353,15 +353,13 @@
     document.querySelectorAll('.faq-question').forEach(btn => {
       btn.addEventListener('click', () => {
         const item = btn.closest('.faq-item');
-        item.classList.toggle('open');
-        const item = btn.parentElement;
         const answer = document.getElementById(btn.getAttribute('aria-controls'));
         const expanded = btn.getAttribute('aria-expanded') === 'true';
+        item.classList.toggle('open');
         btn.setAttribute('aria-expanded', String(!expanded));
         if (answer) {
           answer.setAttribute('aria-hidden', expanded ? 'true' : 'false');
         }
-        item.classList.toggle('open');
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- simplify FAQ script to use btn.closest and one `item` reference
- toggle FAQ open class once and keep ARIA attributes in sync

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895038621b08329ac225a375df39990