### PR TITLE
Remove FAQ copy from index

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,6 @@
 
 <section id="faq" class="section faq-block">
   <h2>You’ve got questions. We work in answers.</h2>
-  <p class="faq-intro">FAQ – Dataraiils (11 Questions)</p>
   <div class="faq-container">
   <div class="faq-grid">
 <div class="faq-item">


### PR DESCRIPTION
## Summary
- remove outdated FAQ intro copy from index page

## Testing
- `python3 scripts/contrast_check.py`


------
https://chatgpt.com/codex/tasks/task_e_6895103f61908329af9cbc2eb4d3fe42