### PR TITLE
Simplify FAQ grid layout for responsiveness

### DIFF
--- a/style.css
+++ b/style.css
@@ -678,11 +678,17 @@ transition: opacity 0.3s ease-out;
 
 .faq-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 40px 80px;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 40px;
   max-width: 1200px;
   margin: 0 auto;
   padding: 0 24px;
+}
+
+@media (max-width: 600px) {
+  .faq-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .faq-item {


### PR DESCRIPTION
## Summary
- Limit FAQ grid to two columns with consistent spacing
- Add narrow-screen media query switching to single-column layout

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895166232548329b61c38f90e5206d1