### PR TITLE
feat: improve mobile navigation accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,8 +336,58 @@
 
   const navToggle = document.getElementById('nav-toggle');
   const navMenu = document.getElementById('nav-menu');
+  const navLinks = navMenu.querySelectorAll('.nav-link');
+
+  const focusableSelectors = 'a, button, [tabindex]:not([tabindex="-1"])';
+  let firstFocusable, lastFocusable;
+
+  const trapFocus = (e) => {
+    if (!navMenu.classList.contains('open')) return;
+    if (e.key === 'Escape') {
+      closeMenu();
+      return;
+    }
+    if (e.key !== 'Tab') return;
+    const isShift = e.shiftKey;
+    const active = document.activeElement;
+    if (!isShift && active === lastFocusable) {
+      e.preventDefault();
+      firstFocusable.focus();
+    } else if (isShift && active === firstFocusable) {
+      e.preventDefault();
+      lastFocusable.focus();
+    }
+  };
+
+  const openMenu = () => {
+    navMenu.classList.add('open');
+    document.body.classList.add('menu-open');
+    const focusables = navMenu.querySelectorAll(focusableSelectors);
+    firstFocusable = focusables[0];
+    lastFocusable = focusables[focusables.length - 1];
+    firstFocusable.focus();
+    document.addEventListener('keydown', trapFocus);
+    navToggle.setAttribute('aria-expanded', 'true');
+  };
+
+  const closeMenu = () => {
+    navMenu.classList.remove('open');
+    document.body.classList.remove('menu-open');
+    document.removeEventListener('keydown', trapFocus);
+    navToggle.setAttribute('aria-expanded', 'false');
+    navToggle.focus();
+  };
+
   navToggle.addEventListener('click', () => {
-    navMenu.classList.toggle('open');
+    if (navMenu.classList.contains('open')) {
+      closeMenu();
+    } else {
+      openMenu();
+    }
+  });
+
+  navLinks.forEach(link => {
+    link.addEventListener('click', closeMenu);
   });
 
   const faqItems = document.querySelectorAll('.faq-item');

--- a/style.css
+++ b/style.css
@@ -918,6 +918,19 @@ main > section:nth-of-type(even) {
     #nav-menu.open {
       display: flex;
     }
+    body.menu-open {
+      overflow: hidden;
+    }
+    body.menu-open::before {
+      content: "";
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.5);
+      z-index: 900;
+    }
     .nav-link {
       margin: 8px 0;
     }


### PR DESCRIPTION
## Summary
- add full-screen overlay and body scroll lock when mobile nav is open
- close nav menu after selecting a link and trap focus inside menu for accessibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68973f2f1d248329829df17030294938