### PR TITLE
Add responsive stats cards with icons

### DIFF
--- a/assets/images/icon-broken-tag.svg
+++ b/assets/images/icon-broken-tag.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#9605DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M10 13l-3 3a4 4 0 0 1-5.66-5.66l3-3"/>
+  <path d="M14 11l3-3a4 4 0 0 1 5.66 5.66l-3 3"/>
+  <path d="M8 9l8 6"/>
+</svg>

--- a/assets/images/icon-delay.svg
+++ b/assets/images/icon-delay.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#9605DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <path d="M12 6v6l4 2"/>
+</svg>

--- a/assets/images/icon-rounds.svg
+++ b/assets/images/icon-rounds.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#9605DF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="1 4 1 10 7 10"/>
+  <polyline points="23 20 23 14 17 14"/>
+  <path d="M3.51 15a9 9 0 0 1 13.38-9.36L23 10"/>
+  <path d="M20.49 9a9 9 0 0 1-13.38 9.36L1 14"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -73,11 +73,23 @@
     <div class="cost-wrapper">
       <h2>Delay isn’t annoying. It’s expensive.</h2>
       <p>This isn’t theoretical. This is every campaign.</p>
-      <ul class="stats-list">
-        <li><span class="stat">10 days to traffic</span><span class="equals">=</span><span class="desc">lost revenue</span></li>
-        <li><span class="stat">3x trafficking rounds</span><span class="equals">=</span><span class="desc">15 extra PM hours</span></li>
-        <li><span class="stat">Broken tag</span><span class="equals">=</span><span class="desc">0% attribution</span></li>
-      </ul>
+      <div class="stats-grid">
+        <div class="stats-card">
+          <img src="assets/images/icon-delay.svg" alt="" class="stats-icon" />
+          <div class="stat">10 days to traffic</div>
+          <div class="desc">Lost revenue</div>
+        </div>
+        <div class="stats-card">
+          <img src="assets/images/icon-rounds.svg" alt="" class="stats-icon" />
+          <div class="stat">3x trafficking rounds</div>
+          <div class="desc">15 extra PM hours</div>
+        </div>
+        <div class="stats-card">
+          <img src="assets/images/icon-broken-tag.svg" alt="" class="stats-icon" />
+          <div class="stat">Broken tag</div>
+          <div class="desc">0% attribution</div>
+        </div>
+      </div>
     </div>
   </section>
 

--- a/style.css
+++ b/style.css
@@ -194,20 +194,26 @@ main > section:nth-of-type(even) {
   max-width: 720px;
   margin: 0 auto;
 }
-.stats-list {
-  list-style: none;
-  padding: 0;
-  margin: 32px 0 0;
+.stats-grid {
+  display: grid;
+  gap: 24px;
+  margin-top: 32px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
-.stats-list li {
+.stats-card {
+  background-color: var(--color-white);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 24px;
+  text-align: center;
   display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  padding: 24px 0;
-  border-bottom: 1px solid var(--color-border);
+  flex-direction: column;
+  align-items: center;
 }
-.stats-list li:last-child {
-  border-bottom: none;
+.stats-icon {
+  width: 48px;
+  height: 48px;
+  margin-bottom: 16px;
 }
 .stat {
   font-weight: 700;
@@ -217,10 +223,11 @@ main > section:nth-of-type(even) {
   font-weight: 400;
   font-size: 16px;
 }
-.equals {
-  margin: 0 8px;
-  font-weight: 400;
-  font-size: 16px;
+
+@media (max-width: 600px) {
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Launch Section */


### PR DESCRIPTION
## Summary
- Replace static stats list with responsive card grid and captions
- Style new stats cards for flexible layout on small screens
- Add SVG icons illustrating key campaign metrics

## Testing
- `python scripts/contrast_check.py`


------
https://chatgpt.com/codex/tasks/task_e_68973f3180248329bba8c7828b235960