### PR TITLE
refactor hero min-height for mobile-first

### DIFF
--- a/style.css
+++ b/style.css
@@ -557,12 +557,18 @@ main > section:nth-of-type(even) {
 /* Hero Section */
 .hero {
   position: relative;
-  min-height: max(100vh, 720px);
+  min-height: 100vh;
   display: grid;
   grid-template-columns: repeat(12, 1fr);
   align-items: center;
   overflow: hidden;
   color: var(--color-ink);
+}
+
+@media (min-width: 1024px) {
+  .hero {
+    min-height: 720px;
+  }
 }
 .hero-bg {
   position: absolute;


### PR DESCRIPTION
## Summary
- use mobile-first hero min-height of 100vh
- apply 720px min-height on large screens via media query

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68973f33ceec8329b04e999fe43d6d39