### PR TITLE
Add PWA mobile dashboard

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="manifest" href="manifest.json" />
+  <link rel="stylesheet" href="../style.css" />
+  <title>Dataraiils Dashboard</title>
+  <style>
+    .app-header {
+      background: var(--color-brand);
+      color: var(--color-white);
+      padding: 1rem;
+      text-align: center;
+    }
+    .card {
+      background: var(--color-bg-light);
+      border: 1px solid var(--color-border);
+      border-radius: 8px;
+      padding: 1rem;
+      margin: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <header class="app-header">
+    <h1>Dashboard</h1>
+  </header>
+  <main>
+    <section class="card">
+      <h2>Welcome</h2>
+      <p>This is your mobile dashboard.</p>
+    </section>
+  </main>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('service-worker.js');
+    }
+  </script>
+</body>
+</html>

--- a/dashboard/manifest.json
+++ b/dashboard/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Dataraiils Dashboard",
+  "short_name": "Dashboard",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#FFFFFF",
+  "theme_color": "#9605DF",
+  "icons": [
+    {
+      "src": "../assets/images/favicon-dataraiils.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "../assets/images/dataraiils-logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/dashboard/service-worker.js
+++ b/dashboard/service-worker.js
@@ -1,0 +1,23 @@
+const CACHE_NAME = 'dashboard-cache-v1';
+const urlsToCache = [
+  './',
+  './index.html',
+  '../style.css',
+  './manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => {
+      return cache.addAll(urlsToCache);
+    })
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request);
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add mobile-focused dashboard using existing color tokens
- include service worker for offline caching
- provide web app manifest enabling installation

## Testing
- `python -m py_compile scripts/contrast_check.py`


------
https://chatgpt.com/codex/tasks/task_e_68973f36a3648329832c7d27f84ff2db