### PR TITLE
Extract logo styling into shared CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <body>
 <header class="nav-bar">
   <div class="logo">
-    <img src="assets/images/dataraiils-logo.png" alt="Dataraiils Logo" style="height: 32px;">
+    <img src="assets/images/dataraiils-logo.png" alt="Dataraiils Logo">
   </div>
   <button id="nav-toggle" aria-label="Toggle navigation">☰</button>
   <nav id="nav-menu">

--- a/privacy.html
+++ b/privacy.html
@@ -12,7 +12,7 @@
 
 <header class="nav-bar">
   <div class="logo">
-    <img src="assets/images/dataraiils-logo.png" alt="Dataraiils Logo" style="height: 32px;">
+    <img src="assets/images/dataraiils-logo.png" alt="Dataraiils Logo">
   </div>
   <button id="nav-toggle" aria-label="Toggle navigation">☰</button>
   <nav id="nav-menu">

--- a/style.css
+++ b/style.css
@@ -156,6 +156,11 @@ main > section:nth-of-type(even) {
   z-index: 1000;
   transition: height 0.3s ease, box-shadow 0.3s ease;
 }
+.logo img {
+  height: 32px;
+  width: auto;
+  margin-right: var(--gutter);
+}
 .nav-link {
   margin-left: 20px;
   color: var(--color-ink);

--- a/terms.html
+++ b/terms.html
@@ -12,7 +12,7 @@
 
 <header class="nav-bar">
   <div class="logo">
-    <img src="assets/images/dataraiils-logo.png" alt="Dataraiils Logo" style="height: 32px;">
+    <img src="assets/images/dataraiils-logo.png" alt="Dataraiils Logo">
   </div>
   <button id="nav-toggle" aria-label="Toggle navigation">☰</button>
   <nav id="nav-menu">


### PR DESCRIPTION
## Summary
- Remove inline height styles from header logo images across pages
- Add centralized `.logo img` rule for consistent sizing and spacing

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974814805083299a180ee1de1aa23a