### PR TITLE
feat: add sticky nav and persistent CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,8 @@
   </nav>
 </header>
 
+<a href="#demo" class="button-primary persistent-cta">Get Demo</a>
+
 <main class="layout-grid">
 
   <section class="hero" id="product">

--- a/privacy.html
+++ b/privacy.html
@@ -23,6 +23,8 @@
   </nav>
 </header>
 
+<a href="index.html#demo" class="button-primary persistent-cta">Get Demo</a>
+
 <main class="layout-grid">
   <section class="section">
     <h1>Privacy Policy</h1>
@@ -70,6 +72,7 @@
   const navBar = document.querySelector('.nav-bar');
   navToggle.addEventListener('click', () => {
     navMenu.classList.toggle('open');
+    document.body.classList.toggle('menu-open');
   });
   window.addEventListener('scroll', () => {
     if (window.scrollY > 10) {

--- a/style.css
+++ b/style.css
@@ -153,6 +153,7 @@ main > section:nth-of-type(even) {
   border-bottom: 1px solid var(--color-border-light);
   position: sticky;
   top: 0;
+  width: 100%;
   z-index: 1000;
   transition: height 0.3s ease, box-shadow 0.3s ease;
 }
@@ -171,6 +172,18 @@ main > section:nth-of-type(even) {
 .nav-bar.scrolled {
   height: 48px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+/* Persistent CTA */
+.persistent-cta {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1100;
+}
+
+body.menu-open .persistent-cta {
+  display: none;
 }
 
 /* Section 1 - Pain */

--- a/terms.html
+++ b/terms.html
@@ -23,6 +23,8 @@
   </nav>
 </header>
 
+<a href="index.html#demo" class="button-primary persistent-cta">Get Demo</a>
+
 <main class="layout-grid">
   <section class="section">
     <h1>Terms of Use</h1>
@@ -70,6 +72,7 @@
   const navBar = document.querySelector('.nav-bar');
   navToggle.addEventListener('click', () => {
     navMenu.classList.toggle('open');
+    document.body.classList.toggle('menu-open');
   });
   window.addEventListener('scroll', () => {
     if (window.scrollY > 10) {


### PR DESCRIPTION
## Summary
- ensure nav bar remains pinned to top of viewport
- add floating "Get Demo" CTA across pages
- hide floating CTA when mobile menu opens

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68976d2e1e088329ab966a78d7ef19f3