### PR TITLE
Remove testimonials section from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,24 +121,6 @@
   </div>
 </section>
 
-<section id="testimonials" class="section testimonials">
-  <h2>What our clients say</h2>
-  <div class="testimonials-grid">
-    <div class="testimonial">
-      <p>“Dataraiils transformed our workflow.”</p>
-      <p class="client">Jane Doe, Media Lead</p>
-    </div>
-    <div class="testimonial">
-      <p>“We ship campaigns in half the time now.”</p>
-      <p class="client">John Smith, Ops Director</p>
-    </div>
-    <div class="testimonial">
-      <p>“The automation is a game changer.”</p>
-      <p class="client">Alex Lee, Digital Strategist</p>
-    </div>
-  </div>
-</section>
-
 <section id="operator-feedback" class="section testimonials">
   <h2>Operator feedback</h2>
   <div class="testimonials-grid">


### PR DESCRIPTION
## Summary
- remove outdated testimonials section from landing page

## Testing
- `python scripts/contrast_check.py`


------
https://chatgpt.com/codex/tasks/task_e_68976f17a8788329ad9658df06c734d4