### PR TITLE
Align hero heading typography with base style

### DIFF
--- a/style.css
+++ b/style.css
@@ -621,10 +621,10 @@ body.menu-open .persistent-cta {
   justify-content: center;
 }
 .hero h1 {
-  font-size: 60px;
+  font-size: 48px;
   font-weight: 700;
-  line-height: 1.2;
-  margin-bottom: 16px;
+  line-height: 1.3;
+  margin-bottom: 32px;
 }
 .hero .lead {
   font-size: 20px;
@@ -866,7 +866,7 @@ body.menu-open .persistent-cta {
       padding: 100px 0;
     }
     h1 {
-      font-size: 36px;
+      font-size: 48px;
     }
     .hero {
       grid-template-columns: 1fr;
@@ -882,7 +882,7 @@ body.menu-open .persistent-cta {
       align-items: center;
     }
     .hero h1 {
-      font-size: 36px;
+      font-size: 48px;
     }
     .hero .lead {
       font-size: 18px;


### PR DESCRIPTION
## Summary
- Match `.hero h1` styles to base `h1` size, line-height, and margin for consistent typography
- Ensure mobile `@media (max-width: 768px)` keeps both `h1` and `.hero h1` at 48px

## Testing
- `python3 scripts/contrast_check.py`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689770e1d3388329a7f5a0404d4931b4